### PR TITLE
tidying up test names; minor consistency/convention changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-.idea/
-build/
-out/
+.gradle/
 
+.idea/
+*.iml
+
+build/

--- a/src/main/java/org/xpdojo/bank/Account.java
+++ b/src/main/java/org/xpdojo/bank/Account.java
@@ -11,30 +11,31 @@ import static org.xpdojo.bank.Money.*;
 import static org.xpdojo.bank.Result.failure;
 import static org.xpdojo.bank.Result.success;
 import static org.xpdojo.bank.Transaction.*;
-import static org.xpdojo.bank.Transaction.Deposit;
+import static org.xpdojo.bank.Transaction.Deposit.depositOf;
 import static org.xpdojo.bank.Transaction.Withdraw;
+import static org.xpdojo.bank.Transaction.Withdraw.withdrawalOf;
 
 public class Account {
 
     private final List<Transaction> transactions = new ArrayList<>();
-    
+
     public static Account emptyAccount() {
         return accountWithBalance(ZERO);
     }
 
     public Money balance() {
-	 	return transactions.stream().reduce(sum()).orElse(Deposit.deposit(ZERO)).getAmount();
+	 	return transactions().reduce(sum()).orElse(depositOf(ZERO)).amount();
     }
 
 	public void deposit(Money amount) {
-        transactions.add(Deposit.deposit(amount));
+        transactions.add(depositOf(amount));
     }
 
     public Result withdraw(Money amount) {
-        if (balance().isLessThan(amount)) 
+        if (balance().isLessThan(amount))
             return failure();
-        
-        transactions.add(Withdraw.withdraw(amount));
+
+        transactions.add(withdrawalOf(amount));
         return success();
     }
 
@@ -44,17 +45,16 @@ public class Account {
             receiver.deposit(amount);
         }
     }
-    
-    public String generate(Statement statement, Writer writer) throws IOException {
+
+    public String writeStatement(Statement statement, Writer writer) throws IOException {
         statement.writeTo(writer);
         return writer.toString();
     }
-    
-    public Stream<Transaction> stream() {
+
+    Stream<Transaction> transactions() {
     	return transactions.stream();
 	}
 
-    
     private Account(Money balance) {
         deposit(balance);
     }
@@ -64,6 +64,6 @@ public class Account {
     }
 
     private BinaryOperator<Transaction> sum() {
-        return (a, b) -> new Identity(b.against(a).getAmount());
+        return (a, b) -> new Identity(b.against(a).amount());
     }
 }

--- a/src/main/java/org/xpdojo/bank/BalanceStatement.java
+++ b/src/main/java/org/xpdojo/bank/BalanceStatement.java
@@ -10,11 +10,11 @@ import static java.time.format.DateTimeFormatter.ofPattern;
 
 public class BalanceStatement implements Statement {
 
-	private final int MAX_WIDTH = 30;
-	
-	private final Account account;
-	private final Clock clock;
-	private final String newLine = System.getProperty("line.separator");
+	private static final int MAX_WIDTH = 30;
+    private static final String NEW_LINE = System.getProperty("line.separator");
+
+    private final Account account;
+    private final Clock clock;
 
 	public BalanceStatement(Account account, Clock clock) {
 		this.account = account;
@@ -26,22 +26,22 @@ public class BalanceStatement implements Statement {
 		writer.append(header());
 		writer.append(preamble(clock.now()));
 		writer.append(balance());
-		writer.append(newLine);
+		writer.append(NEW_LINE);
 		writer.append(footer());
 	}
 	
 	private String header() {
-		return "-----------------------------" + newLine +
-			   "         XP DOJO BANK        " + newLine +
-			   "-----------------------------" + newLine +
-			   newLine;
+		return "-----------------------------" + NEW_LINE +
+			   "         XP DOJO BANK        " + NEW_LINE +
+			   "-----------------------------" + NEW_LINE +
+                NEW_LINE;
 	}
 	
 	private String preamble(Instant instant) {
-		return "Terminal #            1003423" + newLine +
-			   "Date                 " + getDate(instant) + newLine +
-			   "Time 24H                " + getTime(instant) + newLine + newLine +
-			   "Account           XXXXXXXXXXX" + newLine;
+		return "Terminal #            1003423" + NEW_LINE +
+			   "Date                 " + getDate(instant) + NEW_LINE +
+			   "Time 24H                " + getTime(instant) + NEW_LINE + NEW_LINE +
+			   "Account           XXXXXXXXXXX" + NEW_LINE;
 	}
 	
 	private String getDate(Instant instant) {
@@ -54,7 +54,7 @@ public class BalanceStatement implements Statement {
 	
 	private String balance() {
 		String balance = account.balance().toString();
-		return "Your current balance is:     " + newLine + newLine + padLeft(balance, MAX_WIDTH - 1) + newLine;
+		return "Your current balance is:     " + NEW_LINE + NEW_LINE + padLeft(balance, MAX_WIDTH - 1) + NEW_LINE;
 	}
 
 	private static String padLeft(String value, int amount) {
@@ -62,9 +62,9 @@ public class BalanceStatement implements Statement {
 	}
 	
 	private String footer() {
-		return newLine +
-			   "  for great deals on loans   " + newLine +
-			   "  visit https://xpdojo.org   " + newLine +
+		return NEW_LINE +
+			   "  for great deals on loans   " + NEW_LINE +
+			   "  visit https://xpdojo.org   " + NEW_LINE +
 			   "-----------------------------";
 	}
 }

--- a/src/main/java/org/xpdojo/bank/FullStatement.java
+++ b/src/main/java/org/xpdojo/bank/FullStatement.java
@@ -8,7 +8,7 @@ import static java.util.stream.Collectors.joining;
 
 public class FullStatement implements Statement {
 
-	private final String newLine = System.getProperty("line.separator");
+	private static final String NEW_LINE = System.getProperty("line.separator");
 	
 	private final Account account;
 
@@ -18,10 +18,10 @@ public class FullStatement implements Statement {
 
 	@Override
 	public void writeTo(Writer writer) throws IOException {
-		writer.append(account.stream().map(getLine()).collect(joining(newLine)));
+		writer.append(account.transactions().map(toStatementLine()).collect(joining(NEW_LINE)));
 	}
 
-	private Function<Transaction, String> getLine() {
-		return transaction -> transaction.getClass().getSimpleName() + " " + transaction.getAmount().toString();
+	private Function<Transaction, String> toStatementLine() {
+		return transaction -> transaction.getClass().getSimpleName() + " " + transaction.amount().toString();
 	}
 }

--- a/src/main/java/org/xpdojo/bank/Transaction.java
+++ b/src/main/java/org/xpdojo/bank/Transaction.java
@@ -4,16 +4,15 @@ public abstract class Transaction {
 
 	private final Money amount;
 
-	public Transaction(Money amount) {
+	Transaction(Money amount) {
 		this.amount = amount;
 	}
 
 	abstract Transaction against(Transaction other);
 
-	public Money getAmount() {
+	public Money amount() {
 		return amount;
-	};
-
+	}
 
 	public static class Deposit extends Transaction {
 		
@@ -21,20 +20,27 @@ public abstract class Transaction {
 			super(amount);
 		}
 
-		public static Deposit deposit(Money amount) {
+		public static Deposit depositOf(Money amount) {
 			return new Deposit(amount);
+		}
+
+		public static Deposit deposit(Money amount) {
+			return depositOf(amount);
 		}
 
 		public Transaction against(Transaction other) {
 			return new Identity(other.amount.plus(super.amount));
 		}
-
 	}
 
 	public static class Withdraw extends Transaction {
 
-		public static Withdraw withdraw(Money amount) {
+		public static Withdraw withdrawalOf(Money amount) {
 			return new Withdraw(amount);
+		}
+
+		public static Withdraw withdraw(Money amount) {
+			return withdrawalOf(amount);
 		}
 
 		private Withdraw(Money amount) {
@@ -87,7 +93,7 @@ public abstract class Transaction {
 //		this.direction = direction;
 //	}
 //
-//	public Money getAmount() {
+//	public Money amount() {
 //		return amount;
 //	}
 //

--- a/src/test/acceptance/java/org/xpdojo/bank/ViewBalanceSlipPrintoutFixture.java
+++ b/src/test/acceptance/java/org/xpdojo/bank/ViewBalanceSlipPrintoutFixture.java
@@ -1,7 +1,6 @@
 package org.xpdojo.bank;
 
 import org.concordion.api.ConcordionResources;
-import org.concordion.api.ExpectedToFail;
 import org.concordion.integration.junit4.ConcordionRunner;
 import org.junit.runner.RunWith;
 
@@ -30,7 +29,7 @@ public class ViewBalanceSlipPrintoutFixture {
 
 	public String printBalanceSlip() throws IOException {
 		Writer writer = new StringWriter();
-		account.generate(new BalanceStatement(account, clock), writer);
+		account.writeStatement(new BalanceStatement(account, clock), writer);
 		return writer.toString();
 	}
 }

--- a/src/test/unit/java/org/xpdojo/bank/AccountTest.java
+++ b/src/test/unit/java/org/xpdojo/bank/AccountTest.java
@@ -48,7 +48,7 @@ class AccountTest {
 	}
 
 	@Test
-	void moneyCanBeTransferredBetweenAccounts() {
+	void transferShouldMoveMoneyFromOneAccountToAnother() {
 		Account sender = accountWithBalance(amountOf(10));
 		Account receiver = emptyAccount();
 
@@ -59,7 +59,7 @@ class AccountTest {
 	}
 
 	@Test
-	void moneyShouldNotBeTransferredWhenItTakesSendingAccountOverdrawn() {
+	void transferShouldNotBeAppliedWhenItTakesSendingAccountOverdrawn() {
 		Account sender = emptyAccount();
 		Account receiver = emptyAccount();
 
@@ -70,10 +70,9 @@ class AccountTest {
 	}
 
 	@Test
-	void canRetrieveABalanceSlip() throws IOException {
-		Account account = accountWithBalance(amountOf(1005));
-		Statement slip = writer -> writer.append("BALANCE SLIP GENERATED");
-		assertThat(account.generate(slip, new StringWriter())).isEqualTo("BALANCE SLIP GENERATED");
+	void statementShouldBeWrittenToSuppliedWriter() throws IOException {
+		Account account = emptyAccount();
+		Statement statement = writer -> writer.append("STATEMENT GENERATED");
+		assertThat(account.writeStatement(statement, new StringWriter())).isEqualTo("STATEMENT GENERATED");
 	}
-	
 }

--- a/src/test/unit/java/org/xpdojo/bank/MoneyTest.java
+++ b/src/test/unit/java/org/xpdojo/bank/MoneyTest.java
@@ -1,6 +1,8 @@
 package org.xpdojo.bank;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -9,43 +11,45 @@ import static org.xpdojo.bank.Money.amountOf;
 class MoneyTest {
 
 	@Test
-	void addingMonies() {
+	void addingAnAmountShouldGiveTheSumOfTheTwoAmounts() {
 		assertThat(amountOf(10).plus(amountOf(14)), is(amountOf(24)));
 	}
 
 	@Test
-	void addingNegativeMonies() {
+	void addingANegativeAmountShouldSubtractTheEquivalentPositiveAmount() {
 		assertThat(amountOf(10).plus(amountOf(-14)), is(amountOf(-4)));
 	}
 
 	@Test
-	void takingMoniesAway() {
+	void subtractingAnAmountShouldGiveTheSubtractedSum() {
 		assertThat(amountOf(14).minus(amountOf(10)), is(amountOf(4)));
 	}
 
 	@Test
-	void takingMoniesAwayWhenSubtractionIsGreaterThanInitialValue() {
+	void subtractingMoreThanTheCurrentAmountShouldGiveANegativeResult() {
 		assertThat(amountOf(10).minus(amountOf(14)), is(amountOf(-4)));
 	}
 
 	@Test
-	void takingNegativeMoniesAway() {
+	void subtractingANegativeAmountShouldAddTheEquivalentPositiveAmount() {
 		assertThat(amountOf(10).minus(amountOf(-14)), is(amountOf(24)));
 	}
 
-	@Test
-	void lessThan() {
-		assertThat(amountOf(0).isLessThan(amountOf(0)), is(false));
-		assertThat(amountOf(10).isLessThan(amountOf(10)), is(false));
-		assertThat(amountOf(10).isLessThan(amountOf(11)), is(true));
-		assertThat(amountOf(11).isLessThan(amountOf(10)), is(false));
-		assertThat(amountOf(-10).isLessThan(amountOf(10)), is(true));
-		assertThat(amountOf(10).isLessThan(amountOf(-10)), is(false));
+	@ParameterizedTest(name = "{0} is less than {1} should be {2}")
+	@CsvSource({
+			"0, 0, false",
+			"10, 10, false",
+			"10, 11, true",
+			"11, 10, false",
+			"-10, 10, true",
+			"10, -10, false"
+	})
+	void lessThanShouldGiveCorrectResult(long amount1, long amount2, boolean result) {
+		assertThat(amountOf(amount1).isLessThan(amountOf(amount2)), is(result));
 	}
 	
 	@Test
-	public void stringRepresentation() {
+	void stringRepresentationShouldBeFormattedTo2DecimalPlacesWithCommas() {
 		assertThat(amountOf(1000103).toString(), is("1,000,103.00"));
 	}
-	
 }


### PR DESCRIPTION
Tidied up the tests names to include intent.

Also made some changes to fit with Java conventions, except accessor names, where I've dropped the `get` to bring them in line with existing code. I think this not only reads a bit nicer, but also helps dissociate from the idea of JavaBeans (i.e. I don't like exposing the fact we're returning a field - the caller shouldn't know/care what's behind the method).