### PR TITLE
Ensure locale "en_EN" for unit tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 }
 
 test {
+    systemProperty "user.country", "EN"
+    systemProperty "user.language", "en"
     outputs.upToDateWhen { false }
     useJUnitPlatform()
 }


### PR DESCRIPTION
Wrong locale (e.g. de_DE) makes tests fail